### PR TITLE
Update jumpbox_setup.sh

### DIFF
--- a/jumpbox_setup.sh
+++ b/jumpbox_setup.sh
@@ -172,7 +172,7 @@ create_creds() {
 		create_creds
 	fi
 	echo "[+] Setting Vault data"
-	vault kv put -mount=seclab seclab proxmox_api_id=$proxmox_api_id proxmox_api_token=$proxmox_api_token seclab_user=$seclab_user seclab_password=$seclab_password seclab_windows_password=$seclab_windows_password seclab_windows_domain_password=$seclab_windows_domain_password seclab_ssh_key="$(cat ~/.ssh/id_rsa.pub)"
+	vault kv put -mount=seclab seclab proxmox_api_id=$proxmox_api_id proxmox_api_token=$proxmox_api_token seclab_user=$seclab_user seclab_password=$seclab_password seclab_windows_password=$seclab_windows_password seclab_windows_domain_password=$seclab_windows_domain_password seclab_ssh_key=@$HOME/.ssh/id_rsa.pub
 }
 
 append_rcs() {


### PR DESCRIPTION
Fixes:
```
➜  Vault git:(homelab) vault kv put -mount=seclab test_kv seclab_ssh_key=$(cat ~/.ssh/id_rsa.pub)
Failed to parse K=V data: invalid key/value pair "<user>@homelab-jumpbox": format must be key=value
```