### PR TITLE
Update jumpbox_setup.sh

### DIFF
--- a/jumpbox_setup.sh
+++ b/jumpbox_setup.sh
@@ -188,7 +188,7 @@ create_creds() {
 	fi
 	echo "[+] Setting Vault data"
  	USER_HOME_DIR=$(getent passwd "$USER" | cut -d: -f6)
-	vault kv put -mount=seclab seclab proxmox_api_id=$proxmox_api_id proxmox_api_token=$proxmox_api_token seclab_user=$seclab_user seclab_password=$seclab_password seclab_windows_password=$seclab_windows_password seclab_windows_domain_password=$seclab_windows_domain_password seclab_ssh_key=@$USER_HOME_DIR/.ssh/id_rsa.pub)
+	vault kv put -mount=seclab seclab proxmox_api_id=$proxmox_api_id proxmox_api_token=$proxmox_api_token seclab_user=$seclab_user seclab_password=$seclab_password seclab_windows_password=$seclab_windows_password seclab_windows_domain_password=$seclab_windows_domain_password seclab_ssh_key=@$USER_HOME_DIR/.ssh/id_rsa.pub
 }
 
 append_rcs() {

--- a/jumpbox_setup.sh
+++ b/jumpbox_setup.sh
@@ -187,7 +187,8 @@ create_creds() {
 		create_creds
 	fi
 	echo "[+] Setting Vault data"
-	vault kv put -mount=seclab seclab proxmox_api_id=$proxmox_api_id proxmox_api_token=$proxmox_api_token seclab_user=$seclab_user seclab_password=$seclab_password seclab_windows_password=$seclab_windows_password seclab_windows_domain_password=$seclab_windows_domain_password seclab_ssh_key=@/home/$USER/.ssh/id_rsa.pub)
+ 	USER_HOME_DIR=$(getent passwd "$USER" | cut -d: -f6)
+	vault kv put -mount=seclab seclab proxmox_api_id=$proxmox_api_id proxmox_api_token=$proxmox_api_token seclab_user=$seclab_user seclab_password=$seclab_password seclab_windows_password=$seclab_windows_password seclab_windows_domain_password=$seclab_windows_domain_password seclab_ssh_key=@$USER_HOME_DIR/.ssh/id_rsa.pub)
 }
 
 append_rcs() {


### PR DESCRIPTION
To fix the following issue when running the setup script as root:

`Failed to parse K=V data: invalid key/value pair "seclab_ssh_key=@/home/root/.ssh/id_rsa.pub": error reading file: open /home/root/.ssh/id_rsa.pub: no such file or directory `

Get the configured home directory for the user running the script via `getent passwd "$USER"` instead of assuming `/home/$USER` (`$HOME` might also be feasible).