### PR TITLE
Update kali.preseed.example

### DIFF
--- a/Packer/kali/http/kali.preseed.example
+++ b/Packer/kali/http/kali.preseed.example
@@ -27,7 +27,7 @@ d-i apt-setup/enable-source-repositories boolean false
 #d-i debian-installer/allow_unauthenticated boolean true
 
 # Add proper source repositories
-d-i apt-setup/local0/repository string http://http.kali.org/kali kali-rolling main contrib non-free
+d-i apt-setup/local0/repository string http://http.kali.org/kali kali-rolling main contrib non-free non-free-firmware
 
 d-i apt-setup/local0/comment string Main repo
 d-i apt-setup/local0/source boolean false

--- a/jumpbox_setup.sh
+++ b/jumpbox_setup.sh
@@ -188,7 +188,7 @@ create_creds() {
 	fi
 	echo "[+] Setting Vault data"
  	USER_HOME_DIR=$(getent passwd "$USER" | cut -d: -f6)
-	vault kv put -mount=seclab seclab proxmox_api_id=$proxmox_api_id proxmox_api_token=$proxmox_api_token seclab_user=$seclab_user seclab_password=$seclab_password seclab_windows_password=$seclab_windows_password seclab_windows_domain_password=$seclab_windows_domain_password seclab_ssh_key=@$USER_HOME_DIR/.ssh/id_rsa.pub)
+	vault kv put -mount=seclab seclab proxmox_api_id=$proxmox_api_id proxmox_api_token=$proxmox_api_token seclab_user=$seclab_user seclab_password=$seclab_password seclab_windows_password=$seclab_windows_password seclab_windows_domain_password=$seclab_windows_domain_password seclab_ssh_key=@$USER_HOME_DIR/.ssh/id_rsa.pub
 }
 
 append_rcs() {

--- a/jumpbox_setup.sh
+++ b/jumpbox_setup.sh
@@ -187,7 +187,8 @@ create_creds() {
 		create_creds
 	fi
 	echo "[+] Setting Vault data"
-	vault kv put -mount=seclab seclab proxmox_api_id=$proxmox_api_id proxmox_api_token=$proxmox_api_token seclab_user=$seclab_user seclab_password=$seclab_password seclab_windows_password=$seclab_windows_password seclab_windows_domain_password=$seclab_windows_domain_password seclab_ssh_key=@/home/$USER/.ssh/id_rsa.pub)
+ 	USER_HOME_DIR=$(getent passwd "$USER" | cut -d: -f6)
+	vault kv put -mount=seclab seclab proxmox_api_id=$proxmox_api_id proxmox_api_token=$proxmox_api_token seclab_user=$seclab_user seclab_password=$seclab_password seclab_windows_password=$seclab_windows_password seclab_windows_domain_password=$seclab_windows_domain_password seclab_ssh_key=@$USER_HOME_DIR/.ssh/id_rsa.pub)
 }
 
 append_rcs() {


### PR DESCRIPTION
Add `non-free-firmware` component to sources for successful installation of `kali-linux-firmware` (depends on .

This step fails as `kali-linux-firmware` dependencies moved from `non-free` into `non-free-firmware` [1].

If this component is non-existent, the preseeded step "Select and install software" fails, causing the automatic installation to abort.

[1] https://www.kali.org/blog/non-free-firmware-transition/