### PR TITLE
Fixed typos that caused script to fail, added dependency in jumpbox_setup.sh

### DIFF
--- a/Scripts/jumpbox_setup.sh
+++ b/Scripts/jumpbox_setup.sh
@@ -13,6 +13,7 @@ install_tools() {
 	echo "[+] Installing baseline tools"
 	sudo apt update
 	sudo apt install -y \
+		expect \
 		tmux \
 		vim-gtk3 \
 		terminator \
@@ -171,7 +172,7 @@ create_creds() {
 	echo -n "Enter password to unlock $KPXC_DB_PATH: "
 	read -s kpxc_pass
 	expect << EOF
-spawn keepassxc-cli add -u $ssh_pubkey -p "$KPXC_DATABASE" Seclab/seclab_ssh_key
+spawn keepassxc-cli add -u $ssh_pubkey -p "$KPXC_DB_PATH" Seclab/seclab_ssh_key
 expect "Enter password to unlock $KPXC_DB_PATH:"
 send {$kpxc_pass}
 send "\n"
@@ -296,7 +297,7 @@ if [[ $confirm == "" ]] || [[ $confirm == "Y" ]]; then
 	create_creds
 	install_fish
 	initialize_pki
-	intialize_caddy
+	initialize_caddy
 	append_rcs
 	echo "[+] Setup finished!"
 else


### PR DESCRIPTION
This PR fixes a few issues that were causing jumpbox_setup.sh to fail:

1. The `expect` package is now included as a dependency since it's needed for SSH setup and isn't preinstalled on some systems (like Lubuntu).

2. Fixed a typo in the function call for `initialize_caddy` (it was misspelled as `intialize_caddy`), so the Caddy server can start up properly now.

3. Fixed a typo that was stopping the SSH key from being added to seclab.kpxc. The variable `KPXC_DB_PATH` was mistakenly called KPXC_DATABASE.
