### PR TITLE
Create 00-netplan.yaml

### DIFF
--- a/Terraform/velociraptor/00-netplan.yaml
+++ b/Terraform/velociraptor/00-netplan.yaml
@@ -1,0 +1,17 @@
+network:
+  ethernets:
+    enp6s18:
+      dhcp4: false
+      addresses:
+        - 192.168.99.14/24
+      nameservers:
+          addresses:
+            - 192.168.99.1
+      routes:
+      - to: 0.0.0.0/0
+        via: 192.168.99.1
+        metric: 99
+    enp6s19:
+      dhcp4: true
+      dhcp-identifier: mac
+  version: 2


### PR DESCRIPTION
Velo's Terraform Plan requires a netplan file. 

Arbitrarily picked "14" for the last octet for the enp6s18 interface